### PR TITLE
Adding ValidationGroups annotation to specify validation groups, refe…

### DIFF
--- a/src/main/java/ru/vyarus/guice/validator/GuiceMethodValidator.java
+++ b/src/main/java/ru/vyarus/guice/validator/GuiceMethodValidator.java
@@ -32,10 +32,17 @@ public class GuiceMethodValidator implements MethodInterceptor {
 
     @Override
     public Object invoke(final MethodInvocation ctx) throws Throwable {
+
+        Class[] groups = new Class[0];
+        if (ctx.getMethod().isAnnotationPresent(ValidationGroups.class)) {
+            groups = ctx.getMethod().getAnnotation(ValidationGroups.class).value();
+        }
+
         Set<ConstraintViolation<Object>> violations = validator.validateParameters(
                 ctx.getThis(),
                 ctx.getMethod(),
-                ctx.getArguments()
+                ctx.getArguments(),
+                groups
         );
 
         if (!violations.isEmpty()) {
@@ -50,7 +57,8 @@ public class GuiceMethodValidator implements MethodInterceptor {
         violations = validator.validateReturnValue(
                 ctx.getThis(),
                 ctx.getMethod(),
-                result
+                result,
+                groups
         );
 
         if (!violations.isEmpty()) {

--- a/src/main/java/ru/vyarus/guice/validator/ValidationGroups.java
+++ b/src/main/java/ru/vyarus/guice/validator/ValidationGroups.java
@@ -1,0 +1,13 @@
+package ru.vyarus.guice.validator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ METHOD, FIELD, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+public @interface ValidationGroups {
+    Class<?>[] value() default {};
+}


### PR DESCRIPTION
…rring to that in GuiceMethodValidator

I wanted to support using Validation groups as part of guice-validator.  Unfortunately, we are stuck on 1.0.2 because, among other reasons, we still require Guice 3.0 instead of 4.0.  So the changes in this PR could apply directly to 1.0.2 or to 1.1.x with some conflict resolution.