### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - TRAVIS=true
 
 install: ./gradlew assemble --no-daemon
-script: travis_wait 20 ./gradlew check --no-daemon
+script: ./gradlew check --no-daemon
 
 after_success:
   - ./gradlew jacocoTestReport --no-daemon


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
